### PR TITLE
BST 수정 및 FINAL.md BST 내용 추가

### DIFF
--- a/DevSet/IntSetBST.cpp
+++ b/DevSet/IntSetBST.cpp
@@ -39,7 +39,7 @@ private:
 		if (node == NULL) return newNode(key);
 
 		/* Otherwise, recur down the tree */
-		if (key < node->key)
+		if (key <= node->key)
 			node->left = bst_insert(node->left, key);
 		else if (key > node->key)
 			node->right = bst_insert(node->right, key);

--- a/FINAL.md
+++ b/FINAL.md
@@ -1,1 +1,28 @@
 # DevSet06
+-------------
+##IntSetBST
+**1. Sorting**
+![default](https://user-images.githubusercontent.com/34343170/41650795-d83ad2de-74b9-11e8-9488-b36ec00595b9.PNG)
+BST로 정렬하는 것은 Tree를 만드는 것과 같다. Tree를 만들면서 데이터를 정렬하기 때문이다.  
+위 그림과 같이 키 값과 같거나 보다 작으면 Left Child를 만들고 반대라면 Right Child를 만들며 정렬한다.  
+![default](https://user-images.githubusercontent.com/34343170/41651060-943c2834-74ba-11e8-9d55-3491f35e7905.PNG)
+이후 출력할 때는 inorder로 트리를 순회하여 배열에 값을 오름차순으로 입력하였다.  
+
+**2. Algorithm Test**
+![default](https://user-images.githubusercontent.com/34343170/41651348-5160ecce-74bb-11e8-9e9f-81d6c1b7e5aa.PNG)
+테스트는 크게 2가지로 나누어 하였다.
+첫 번째는 Tree를 구현하는 데 걸리는 시간을 측정하였고 두 번째는 정렬된 값이 정확한지 체크하였다.  
+
+ **1) Insert Time Test**
+![default](https://user-images.githubusercontent.com/34343170/41651504-afbec016-74bb-11e8-92f8-95d91c3717b4.PNG)
+Tree에 Key들을 Insert하는 시간을 검증하는 코드이다. 각각 Worst Case로 내림차순 된 Input, 오름차순 된 Input, 일반적인 Random Input을 가지고 테스트하였다. 결과는 내림차순,오름차순으로 정렬되있는 Input을 받으면 약 1초의 시간이 걸린다. 왜냐하면 Tree를 구현하는 데 한 쪽으로만(Left,Right) Tree가 생성되기 때문에 Tree의 높이가 입력개수인 n이 되기 때문이다. 그렇다면 한 개의 Key Node를 생성하기 위해서 n개의 Node를 전부 확인해봐야한다. 반면에 Random Input을 넣어주는 경우에는 적절하게 배분이 된다면 log(n)만큼만 검사하면 되어 훨씬 빠르다. 이는 n의 값이 커질 수 록 더욱 확연한 차이를 확인 할 수 있다.
+
+ **2) Sorting Correct**
+![default](https://user-images.githubusercontent.com/34343170/41651927-c1532906-74bc-11e8-9c85-68f21819678c.PNG)
+내림차순으로 정렬된 Input을 받았을 경우 정확히 정렬하는 지 테스트한 코드이다. expect 배열에 기댓값을 넣었고 정렬하면서 다른 부분이 있으면 result_equal을 false로 만들고 결과 AreEqual메소드로 true인지 검사하였다.
+![default](https://user-images.githubusercontent.com/34343170/41653299-94bfc738-74c0-11e8-8cfe-6c0e1ce4d98f.PNG)
+오름차순으로 진행된 Input이다. 위와 동일하게 진행된다.
+![default](https://user-images.githubusercontent.com/34343170/41653328-b0230468-74c0-11e8-88ad-81d5e565b5b8.PNG)
+Random Input을 정렬하는 코드이다. 기댓값은 "Algorithm.h"에 선언되어있는 기본 sorting 메소드를 사용하여 정렬하였고 그 값과 일치하는지 검사하였다.
+
+결과는 맨위의 사진에서 볼 수 있드시 성공하였다.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ https://github.com/CAU-DOSC/DevSet1
 |------|------|
 | 변정규 | Array, List, BST, BitVec, Bins 초기 구현|
 | 안재홍 |  |
-| 이동규 |  |
+| 이동규 | BST Insert 범위 수정, BST Unit Test |
 | 이서현 |  |
 | 신형철 |  |
 
 ### 특이사항
-* 
+*

--- a/UnitTestBST/UnitTestBST.vcxproj
+++ b/UnitTestBST/UnitTestBST.vcxproj
@@ -99,6 +99,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/UnitTestBST/unittest1.cpp
+++ b/UnitTestBST/unittest1.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "CppUnitTest.h"
 #include "..\DevSet\IntSetBST.cpp"
-#include "..\DevSet\util_func.h"
+#include "../DevSet/util_func.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -10,23 +10,85 @@ namespace UnitTestBST
 	TEST_CLASS(UnitTest1)
 	{
 	public:
-		
-		TEST_METHOD(TestMethod1)
-		{
-			int max_v = 1000000;
-			int max_e = max_v / 100;
-			int *v = new int[max_e];
-			int *expect = new int[max_e]; // 테스트 기댓값;
-			bool result_equal = true;
-			IntSetBST test(max_e, max_v);
+		int max_v = 1000000;
+		int max_e = max_v / 100;
+		int *v = new int[max_e];
+		int *expect = new int[max_e]; // 테스트 기댓값;
+		bool result_equal = true;
 
+		int bigrand(int v) {
+			int r = 0;
+
+			// this will generate a Integer using 30bit(larger than 10^8)
+			for (int i = 0; i < 2; ++i) {
+				r = (r << 15) | (rand() & 0x7FFF);
+			}
+			// return value: 0 to v
+			return r % (v + 1);
+		}
+
+		/* 정렬하는 데 걸리는 시간 */
+		TEST_METHOD(BST_Insert_Desc) // 내림차순 입력
+		{
+			IntSetBST test(max_e, max_v);
+			int j = 0;
+			for (int i = max_e - 1; i >= 0; i--) {
+				test.insert(max_v - j);
+				j++;
+			}
+		}
+		TEST_METHOD(BST_Insert_Asce) // 오름차순 입력
+		{
+			IntSetBST test(max_e, max_v);
+			int j = 0;
+			for (int i = max_e - 1; i >= 0; i--) {
+				test.insert(max_v - j);
+				j++;
+			}
+		}
+		TEST_METHOD(BST_Insert_Rand) // 랜덤 입력
+		{
+			IntSetBST test(max_e, max_v);
+			int temp = 0;
+			for (int i = test.size(); i < max_e; i++) {
+				test.insert(bigrand(max_v));
+			}
+		}
+		/* 총 정렬하는 데 걸리는 시간 및 성공 */
+		TEST_METHOD(BST_Total_Desc)
+		{
+			IntSetBST test1(max_e, max_v);
+			int j = 0;
 			for (int i = max_e-1; i >= 0; i--) {
-				test.insert(i);
-				expect[i] = i;
+				test1.insert(max_v-j);
+				expect[i] = max_v-j;
+				j++;
 			}
 
-			// TODO: 테스트 코드를 여기에 입력합니다.
-			test.report(v);
+			test1.report(v);
+
+			/* 정렬된 값이랑 기대한 값이랑 같은가 */
+			for (int i = 0; i < max_e; i++) {
+				if (expect[i] != v[i]) {
+					result_equal = false; // 다르면 false
+				}
+			}
+
+			Assert::AreEqual(true,result_equal); // 기대값이랑 정렬된 값이 같나?
+		}
+		TEST_METHOD(BST_Total_Rand)
+		{
+			IntSetBST test2(max_e, max_v);
+
+			int temp = 0;
+			for (int i = test2.size(); i < max_e; i++) {
+				temp = bigrand(max_v);
+				test2.insert(temp);
+				expect[i] = temp;
+			}
+
+			test2.report(v);
+			std::sort(expect, expect+(max_e));
 
 			/* 정렬된 값이랑 기대한 값이랑 같은가 */
 			for (int i = 0; i < max_e; i++) {
@@ -35,10 +97,30 @@ namespace UnitTestBST
 				}
 			}
 
-			Assert::AreEqual(0,v[0]); // 가장 작은 값이 맨 처음인가?
-			Assert::AreEqual(max_e - 1, v[max_e - 1]); // 가장 큰 값이 맨 마지막인가?
-			Assert::AreEqual(true,result_equal); // 기대값이랑 정렬된 값이 같나?
+			Assert::AreEqual(true, result_equal); // 기대값이랑 정렬된 값이 같나?
 		}
+		TEST_METHOD(BST_Total_Asce)
+		{
+			IntSetBST test3(max_e, max_v);
 
+			int temp = 0;
+			for (int i = 0; i < max_e; i++) {
+				temp = max_v - max_e + i;
+				test3.insert(temp);
+				expect[i] = temp;
+			}
+
+			test3.report(v);
+			std::sort(expect, expect + (max_e));
+
+			/* 정렬된 값이랑 기대한 값이랑 같은가 */
+			for (int i = 0; i < max_e; i++) {
+				if (expect[i] != v[i]) {
+					result_equal = false;
+				}
+			}
+
+			Assert::AreEqual(true, result_equal); // 기대값이랑 정렬된 값이 같나?
+		}
 	};
 }


### PR DESCRIPTION
 IntSetBST에서 bst_insert 메소드 중 기존에 존재하는 Node의 key 값과 새로들어온 key의 값이 동일하다면 기존에는 Node를 추가하지 않았지만 Left Node를 생성하는 것으로 변경하였습니다. 테스트하는 과정에서 "algorithm.h"에 선언되어있는 sort 메소드와 비교를 하였는 데 sort메소드는 중복된 값도 처리하여서 동일한 비교를 위해 위와같이 변경하였습니다.
 FINAL.md에 BST 간략한 설명 및 Unit Test 설명 추가하였습니다.